### PR TITLE
fix: set SRAM controller mode for NPU power configuration

### DIFF
--- a/debian/patches/series
+++ b/debian/patches/series
@@ -14,3 +14,4 @@ u-boot/0013-include-sunxi_gpio-Add-two-extra-GPIO-bank-definitio.patch
 u-boot/0014-board-sunxi-cubie_board-Initialize-GPIO-state-to-inp.patch
 u-boot/0015-arm-dts-cubie-a7s-Keep-board-ID-detect-power-enabled.patch
 u-boot/0016-drivers-misc-radxa-i2c-eeprom-Fix-macaddr-read-error.patch
+u-boot/0017-add-set-sramc-mode-to-npu.patch

--- a/debian/patches/u-boot/0017-add-set-sramc-mode-to-npu.patch
+++ b/debian/patches/u-boot/0017-add-set-sramc-mode-to-npu.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Feng Zhang <feng@radxa.com>
+Date: Wed, 26 Feb 2025 09:18:00 +0000
+Subject: [PATCH] add: set sramc mode to npu
+
+Signed-off-by: Feng Zhang <feng@radxa.com>
+---
+ src/arch/arm/mach-sunxi/board.c | 22 ++++++++++++++++++++++
+ 1 file changed, 22 insertions(+)
+
+diff --git a/src/arch/arm/mach-sunxi/board.c b/src/arch/arm/mach-sunxi/board.c
+index b82acf540f7..2fad5039f8f 100644
+--- a/src/arch/arm/mach-sunxi/board.c
++++ b/src/arch/arm/mach-sunxi/board.c
+@@ -471,6 +471,26 @@ u32 spl_mmc_boot_mode(struct mmc *mmc, const u32 boot_device)
+ 	return result;
+ }
+ 
++#ifdef CONFIG_MACH_SUN60I_A733
++#define SUNXI_SYSCTRL_BASE	       0x03000000
++#define SRAM_CTRL_REG2 (SUNXI_SYSCTRL_BASE + 0x8)
++int sunxi_set_sramc_mode(void)
++{
++	u32 reg_val;
++
++	/* SRAM:set sram to npu, default boot mode */
++	reg_val = readl(SRAM_CTRL_REG2);
++	reg_val &= ~(0x1 << 1);
++	writel(reg_val, SRAM_CTRL_REG2);
++	debug("set sram to npu\n");
++
++	reg_val = readl(SRAM_CTRL_REG2);
++	if (reg_val & (0x1 << 1))
++		pr_err("set sram to npu fail!\n");
++	return 0;
++}
++#endif
++
+ void board_init_f(ulong dummy)
+ {
+ 	sunxi_sram_init();
+@@ -491,6 +511,9 @@ void board_init_f(ulong dummy)
+ 	i2c_init(CONFIG_SYS_I2C_SPEED, CONFIG_SYS_I2C_SLAVE);
+ #endif
+ 	sunxi_board_init();
++#ifdef CONFIG_MACH_SUN60I_A733
++	sunxi_set_sramc_mode();
++#endif
+ }
+ #endif /* CONFIG_XPL_BUILD */
+ 
+-- 
+2.49.0


### PR DESCRIPTION
Configure SRAM_CTRL_REG2 to set SRAM to NPU mode during early board initialization (board_init_f). This ensures proper power routing for the NPU on sun60i-a733 platform.
Fix the issue where NPU inference cannot be used in the kernel